### PR TITLE
Add LiteLLM multi-provider models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MindForge is a Python library designed to provide sophisticated memory managemen
 *   **Concept Graph:**  Builds and maintains a graph of relationships between concepts, enabling spreading activation for enhanced retrieval.
 *   **Semantic Clustering:**  Groups memories based on their embeddings, improving retrieval efficiency and identifying related concepts.
 *   **Flexible Storage:**  Provides `SQLiteEngine` and `SQLiteVecEngine` for persistent storage, with options for optimizing performance.
-*   **Model Agnostic:**  Supports OpenAI, Azure OpenAI, and Ollama models for chat and embedding generation, with an easily extensible interface for adding other models.
+*   **Model Agnostic:**  Supports OpenAI, Azure OpenAI, Ollama, and any provider available through `litellm`, with an easily extensible interface for adding other models.
 *   **Built-in Utilities:**  Includes tools for logging, monitoring, vector optimization, profiling, and input validation.
 *   **Configurable:** Uses dataclasses for easy configuration of memory, vector, model, and storage parameters.
 
@@ -165,7 +165,36 @@ manager = MemoryManager(
 response = manager.process_input(query="Explain quantum physics.")
 print(f"Response: {response}")
 
-# --- Example 4:  Using MemoryStore (FAISS) ---
+# --- Example 4: Using LiteLLM for Multi-Provider Support ---
+
+config = AppConfig()
+config.model.use_model = "litellm"
+config.model.chat_model_name = "gpt-3.5-turbo"  # Any model supported by litellm
+config.model.embedding_model_name = "text-embedding-3-small"
+config.model.chat_api_key = "your_provider_api_key"
+config.model.embedding_api_key = "your_provider_api_key"
+config.model.litellm_base_url = "https://api.openai.com/v1"  # Example base URL
+
+from mindforge.models.chat import LiteLLMChatModel
+from mindforge.models.embedding import LiteLLMEmbeddingModel
+
+chat_model = LiteLLMChatModel(
+    model_name=config.model.chat_model_name,
+    api_key=config.model.chat_api_key,
+    base_url=config.model.litellm_base_url,
+)
+embedding_model = LiteLLMEmbeddingModel(
+    model_name=config.model.embedding_model_name,
+    api_key=config.model.embedding_api_key,
+    base_url=config.model.litellm_base_url,
+)
+
+manager = MemoryManager(chat_model=chat_model, embedding_model=embedding_model, config=config)
+
+response = manager.process_input(query="Tell me a joke.")
+print(f"Response: {response}")
+
+# --- Example 5:  Using MemoryStore (FAISS) ---
 from mindforge.core.memory_store import MemoryStore
 import numpy as np
 

--- a/mindforge/config.py
+++ b/mindforge/config.py
@@ -37,7 +37,8 @@ class ModelConfig:
     azure_endpoint: Optional[str] = None
     azure_api_version: Optional[str] = None
     ollama_base_url: str = "http://localhost:11434"
-    use_model: str = "openai"  # Added:  Specify which provider to use (openai, azure, ollama)
+    litellm_base_url: Optional[str] = None
+    use_model: str = "openai"  # Added:  Specify which provider to use (openai, azure, ollama, litellm)
 
 
 @dataclass

--- a/mindforge/main.py
+++ b/mindforge/main.py
@@ -4,11 +4,17 @@ import os
 from mindforge.utils.logging import LogManager
 from mindforge.utils.errors import ConfigurationError, ModelError
 from mindforge import MemoryManager
-from mindforge.models.chat import OpenAIChatModel, AzureChatModel, OllamaChatModel
+from mindforge.models.chat import (
+    OpenAIChatModel,
+    AzureChatModel,
+    OllamaChatModel,
+    LiteLLMChatModel,
+)
 from mindforge.models.embedding import (
     OpenAIEmbeddingModel,
     AzureEmbeddingModel,
     OllamaEmbeddingModel,
+    LiteLLMEmbeddingModel,
 )
 from mindforge.storage.sqlite_engine import SQLiteEngine # Import SQLiteEngine
 from mindforge.config import AppConfig  # Import AppConfig
@@ -58,6 +64,18 @@ def initialize_models(config: AppConfig):
             embedding_model = OllamaEmbeddingModel(
                 model_name=config.model.embedding_model_name,
                 base_url=config.model.ollama_base_url,
+            )
+        elif config.model.use_model == "litellm":
+            chat_model = LiteLLMChatModel(
+                model_name=config.model.chat_model_name,
+                api_key=config.model.chat_api_key,
+                base_url=config.model.litellm_base_url,
+            )
+            embedding_model = LiteLLMEmbeddingModel(
+                model_name=config.model.embedding_model_name,
+                api_key=config.model.embedding_api_key,
+                base_url=config.model.litellm_base_url,
+                dimension=config.vector.embedding_dim,
             )
         else:
             raise ConfigurationError(f"Unsupported model provider: {config.model.use_model}")

--- a/mindforge/models/chat/__init__.py
+++ b/mindforge/models/chat/__init__.py
@@ -1,5 +1,6 @@
 from .openai import OpenAIChatModel
 from .azure import AzureChatModel
 from .ollama import OllamaChatModel
+from .litellm import LiteLLMChatModel
 
-__all__ = ["OpenAIChatModel", "AzureChatModel", "OllamaChatModel"]
+__all__ = ["OpenAIChatModel", "AzureChatModel", "OllamaChatModel", "LiteLLMChatModel"]

--- a/mindforge/models/chat/litellm.py
+++ b/mindforge/models/chat/litellm.py
@@ -1,0 +1,50 @@
+import litellm
+from typing import Dict, Any, List
+from ...core.base_model import BaseChatModel
+from ...utils.errors import ModelError
+
+
+class LiteLLMChatModel(BaseChatModel):
+    """Chat model wrapper using litellm for multi-provider support."""
+
+    def __init__(self, model_name: str, api_key: str = None, base_url: str | None = None, extra_params: Dict[str, Any] | None = None):
+        self.model_name = model_name
+        self.api_key = api_key
+        self.base_url = base_url
+        self.extra_params = extra_params or {}
+
+    def _call_completion(self, messages: List[Dict[str, str]]):
+        return litellm.completion(
+            model=self.model_name,
+            messages=messages,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            **self.extra_params,
+        )
+
+    def _get_content(self, resp) -> str:
+        message = resp.choices[0].message
+        return message.get("content") if isinstance(message, dict) else message.content
+
+    def generate_response(self, context: Dict[str, Any], query: str) -> str:
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant with memory."},
+            {"role": "user", "content": f"Context: {context}\nQuery: {query}"},
+        ]
+        try:
+            response = self._call_completion(messages)
+            return self._get_content(response)
+        except Exception as e:
+            raise ModelError(f"LiteLLM error: {e}")
+
+    def extract_concepts(self, text: str) -> List[str]:
+        messages = [
+            {"role": "system", "content": "Extract key concepts from the text, separated by commas."},
+            {"role": "user", "content": text},
+        ]
+        try:
+            response = self._call_completion(messages)
+            content = self._get_content(response)
+            return [c.strip() for c in content.split(',') if c.strip()]
+        except Exception as e:
+            raise ModelError(f"LiteLLM concept extraction error: {e}")

--- a/mindforge/models/embedding/__init__.py
+++ b/mindforge/models/embedding/__init__.py
@@ -1,9 +1,11 @@
 from .openai import OpenAIEmbeddingModel
 from .azure import AzureEmbeddingModel
 from .ollama import OllamaEmbeddingModel
+from .litellm import LiteLLMEmbeddingModel
 
 __all__ = [
     "OpenAIEmbeddingModel",
     "AzureEmbeddingModel",
-    "OllamaEmbeddingModel"
+    "OllamaEmbeddingModel",
+    "LiteLLMEmbeddingModel",
 ]

--- a/mindforge/models/embedding/litellm.py
+++ b/mindforge/models/embedding/litellm.py
@@ -1,0 +1,45 @@
+import numpy as np
+import litellm
+from typing import Dict, Any
+from ...core.base_model import BaseEmbeddingModel
+from ...utils.errors import ModelError
+
+
+class LiteLLMEmbeddingModel(BaseEmbeddingModel):
+    """Embedding model wrapper using litellm."""
+
+    def __init__(
+        self,
+        model_name: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        dimension: int = 1536,
+        extra_params: Dict[str, Any] | None = None,
+    ):
+        self.model_name = model_name
+        self.api_key = api_key
+        self.base_url = base_url
+        self._dimension = dimension
+        self.extra_params = extra_params or {}
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def _call_embedding(self, text: str):
+        return litellm.embedding(
+            model=self.model_name,
+            input=[text],
+            api_key=self.api_key,
+            api_base=self.base_url,
+            **self.extra_params,
+        )
+
+    def get_embedding(self, text: str) -> np.ndarray:
+        try:
+            resp = self._call_embedding(text)
+            item = resp.data[0]
+            embedding = item["embedding"] if isinstance(item, dict) else item.embedding
+            return np.array(embedding)
+        except Exception as e:
+            raise ModelError(f"LiteLLM embedding error: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ dependencies = [
     "scikit-learn>=1.6.1",
     "scipy>=1.10.0",
     "sqlite-vec>=0.1.6",
+    "litellm>=1.34.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.32.3
 scikit-learn>=1.6.1
 scipy>=1.10.0
 sqlite-vec>=0.1.6
+litellm>=1.34.0


### PR DESCRIPTION
## Summary
- integrate LiteLLM-based chat and embedding models
- register new models with imports
- allow config/base URL for LiteLLM provider
- support LiteLLM provider in main initialization
- document new provider with example
- add litellm dependency

## Testing
- `pip install numpy`
- `pip install faiss-cpu openai requests scikit-learn scipy sqlite-vec pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547fef6ad08333b9782479522db9d7