### PR TITLE
Add vector DB engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MindForge is a Python library designed to provide sophisticated memory managemen
 *   **Vector-Based Similarity Search:**  Uses `sqlite-vec` (and optionally FAISS) for fast and efficient retrieval of memories based on semantic similarity.
 *   **Concept Graph:**  Builds and maintains a graph of relationships between concepts, enabling spreading activation for enhanced retrieval.
 *   **Semantic Clustering:**  Groups memories based on their embeddings, improving retrieval efficiency and identifying related concepts.
-*   **Flexible Storage:**  Provides `SQLiteEngine` and `SQLiteVecEngine` for persistent storage, with options for optimizing performance.
+*   **Flexible Storage:**  Provides `SQLiteEngine`, `SQLiteVecEngine`, and optional engines for Redis, PostgreSQL, and ChromaDB vector storage.
 *   **Model Agnostic:**  Supports OpenAI, Azure OpenAI, and Ollama models for chat and embedding generation, with an easily extensible interface for adding other models.
 *   **Built-in Utilities:**  Includes tools for logging, monitoring, vector optimization, profiling, and input validation.
 *   **Configurable:** Uses dataclasses for easy configuration of memory, vector, model, and storage parameters.

--- a/mindforge/storage/__init__.py
+++ b/mindforge/storage/__init__.py
@@ -1,4 +1,13 @@
 from .sqlite_engine import SQLiteEngine
 from .sqlite_vec_engine import SQLiteVecEngine
+from .redis_vec_engine import RedisVectorEngine
+from .postgres_vec_engine import PostgresVectorEngine
+from .chroma_engine import ChromaDBEngine
 
-__all__ = ["SQLiteEngine", "SQLiteVecEngine"] 
+__all__ = [
+    "SQLiteEngine",
+    "SQLiteVecEngine",
+    "RedisVectorEngine",
+    "PostgresVectorEngine",
+    "ChromaDBEngine",
+]

--- a/mindforge/storage/chroma_engine.py
+++ b/mindforge/storage/chroma_engine.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+
+from chromadb import Client
+from chromadb.config import Settings
+
+from .base_storage import BaseStorage
+
+
+class ChromaDBEngine(BaseStorage):
+    """Storage engine backed by ChromaDB."""
+
+    def __init__(self, collection_name: str = "mindforge", embedding_dim: int = 1536):
+        self.embedding_dim = embedding_dim
+        self.client = Client(Settings(anonymized_telemetry=False))
+        self.collection = self.client.get_or_create_collection(collection_name)
+
+    def store_memory(
+        self,
+        memory_data: Dict[str, Any],
+        memory_type: str = "short_term",
+        user_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        metadata = {
+            "prompt": memory_data.get("prompt"),
+            "response": memory_data.get("response"),
+            "memory_type": memory_type,
+        }
+        if user_id:
+            metadata["user_id"] = user_id
+        if session_id:
+            metadata["session_id"] = session_id
+
+        self.collection.add(  # type: ignore[arg-type]
+            ids=[memory_data["id"]],
+            embeddings=[memory_data["embedding"].tolist()],
+            metadatas=[metadata],
+        )
+
+    def retrieve_memories(
+        self,
+        query_embedding: np.ndarray,
+        concepts: List[str],
+        memory_type: str = None,
+        user_id: str = None,
+        session_id: str = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        metadata_filter = {}
+        if memory_type:
+            metadata_filter["memory_type"] = memory_type
+        if user_id:
+            metadata_filter["user_id"] = user_id
+        if session_id:
+            metadata_filter["session_id"] = session_id
+
+        results = self.collection.query(
+            query_embeddings=[query_embedding.tolist()],
+            n_results=limit,
+            where=metadata_filter or None,
+        )
+
+        memories = []
+        for idx, mem_id in enumerate(results["ids"][0]):
+            meta = results["metadatas"][0][idx]
+            memory = {
+                "id": mem_id,
+                "prompt": meta.get("prompt"),
+                "response": meta.get("response"),
+                "memory_type": meta.get("memory_type"),
+                "relevance_score": results["distances"][0][idx],
+            }
+            memories.append(memory)
+        return memories
+
+    def update_memory_level(
+        self,
+        memory_id: str,
+        new_memory_level: str,
+        user_id: str = None,
+        session_id: str = None,
+    ) -> bool:
+        try:
+            results = self.collection.get(ids=[memory_id])
+        except Exception:
+            return False
+
+        if not results["ids"]:
+            return False
+
+        metadata = results["metadatas"][0]
+        metadata["memory_type"] = new_memory_level
+        if user_id:
+            metadata["user_id"] = user_id
+        if session_id:
+            metadata["session_id"] = session_id
+
+        self.collection.update(ids=[memory_id], metadatas=[metadata])
+        return True

--- a/mindforge/storage/postgres_vec_engine.py
+++ b/mindforge/storage/postgres_vec_engine.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import List, Dict, Any, Optional
+import psycopg2
+from psycopg2.extras import Json
+from pgvector.psycopg2 import register_vector
+
+from .base_storage import BaseStorage
+
+
+class PostgresVectorEngine(BaseStorage):
+    """Storage engine using PostgreSQL with pgvector."""
+
+    def __init__(self, dsn: str, embedding_dim: int = 1536):
+        self.dsn = dsn
+        self.embedding_dim = embedding_dim
+        self._initialize_db()
+
+    def _initialize_db(self) -> None:
+        with psycopg2.connect(self.dsn) as conn:
+            register_vector(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS memories (
+                    id TEXT PRIMARY KEY,
+                    prompt TEXT,
+                    response TEXT,
+                    memory_type TEXT,
+                    embedding vector({self.embedding_dim})
+                )
+                """
+            )
+            conn.commit()
+
+    def store_memory(
+        self,
+        memory_data: Dict[str, Any],
+        memory_type: str = "short_term",
+        user_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        with psycopg2.connect(self.dsn) as conn:
+            register_vector(conn)
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO memories (id, prompt, response, memory_type, embedding) VALUES (%s, %s, %s, %s, %s)",
+                (
+                    memory_data["id"],
+                    memory_data.get("prompt"),
+                    memory_data.get("response"),
+                    memory_type,
+                    memory_data["embedding"].tolist(),
+                ),
+            )
+            conn.commit()
+
+    def retrieve_memories(
+        self,
+        query_embedding: np.ndarray,
+        concepts: List[str],
+        memory_type: str = None,
+        user_id: str = None,
+        session_id: str = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        with psycopg2.connect(self.dsn) as conn:
+            register_vector(conn)
+            cur = conn.cursor()
+            sql = "SELECT id, prompt, response, memory_type, embedding <-> %s AS score FROM memories"
+            params = [query_embedding.tolist()]
+            if memory_type:
+                sql += " WHERE memory_type = %s"
+                params.append(memory_type)
+            sql += " ORDER BY embedding <-> %s LIMIT %s"
+            params.extend([query_embedding.tolist(), limit])
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [
+            {
+                "id": r[0],
+                "prompt": r[1],
+                "response": r[2],
+                "memory_type": r[3],
+                "relevance_score": r[4],
+            }
+            for r in rows
+        ]
+
+    def update_memory_level(
+        self,
+        memory_id: str,
+        new_memory_level: str,
+        user_id: str = None,
+        session_id: str = None,
+    ) -> bool:
+        with psycopg2.connect(self.dsn) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE memories SET memory_type = %s WHERE id = %s",
+                (new_memory_level, memory_id),
+            )
+            updated = cur.rowcount
+            conn.commit()
+        return updated > 0

--- a/mindforge/storage/redis_vec_engine.py
+++ b/mindforge/storage/redis_vec_engine.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import List, Dict, Any, Optional
+import redis
+from redisvl.index import SearchIndex
+from redisvl.schema import IndexSchema
+
+from .base_storage import BaseStorage
+
+
+class RedisVectorEngine(BaseStorage):
+    """Storage engine using RedisVL for vector search."""
+
+    def __init__(
+        self, redis_url: str = "redis://localhost:6379", embedding_dim: int = 1536
+    ):
+        self.redis = redis.from_url(redis_url)
+        self.embedding_dim = embedding_dim
+        schema_dict = {
+            "index": {"name": "mindforge", "prefix": "memory:"},
+            "fields": [
+                {"name": "id", "type": "tag"},
+                {"name": "prompt", "type": "text"},
+                {"name": "response", "type": "text"},
+                {"name": "memory_type", "type": "tag"},
+                {
+                    "name": "embedding",
+                    "type": "vector",
+                    "attrs": {"algorithm": "hnsw", "dims": embedding_dim},
+                },
+            ],
+        }
+        schema = IndexSchema.from_dict(schema_dict)
+        self.index = SearchIndex(schema, redis_client=self.redis)
+        try:
+            self.index.create(overwrite=False, drop=False)
+        except Exception:
+            pass
+
+    def store_memory(
+        self,
+        memory_data: Dict[str, Any],
+        memory_type: str = "short_term",
+        user_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        doc = {
+            "id": memory_data["id"],
+            "prompt": memory_data.get("prompt"),
+            "response": memory_data.get("response"),
+            "memory_type": memory_type,
+            "embedding": memory_data["embedding"].tolist(),
+        }
+        self.index.load([doc])
+
+    def retrieve_memories(
+        self,
+        query_embedding: np.ndarray,
+        concepts: List[str],
+        memory_type: str = None,
+        user_id: str = None,
+        session_id: str = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        query = self.index.query.vector(
+            query_embedding.tolist(), "embedding", num_results=limit
+        )
+        if memory_type:
+            query = query.filter(f"@memory_type:{{{memory_type}}}")
+        results = self.index.query(query)
+        memories = []
+        for r in results:
+            memory = {
+                "id": r["id"],
+                "prompt": r.get("prompt"),
+                "response": r.get("response"),
+                "memory_type": r.get("memory_type"),
+                "relevance_score": r.get("vector_score", 0.0),
+            }
+            memories.append(memory)
+        return memories
+
+    def update_memory_level(
+        self,
+        memory_id: str,
+        new_memory_level: str,
+        user_id: str = None,
+        session_id: str = None,
+    ) -> bool:
+        key = f"memory:{memory_id}"
+        if not self.redis.exists(key):
+            return False
+        self.redis.hset(key, "memory_type", new_memory_level)
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,8 @@ dependencies = [
     "scikit-learn>=1.6.1",
     "scipy>=1.10.0",
     "sqlite-vec>=0.1.6",
+    "chromadb>=1.0.0",
+    "redisvl>=0.8.0",
+    "psycopg2-binary>=2.9.0",
+    "pgvector>=0.4.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ requests>=2.32.3
 scikit-learn>=1.6.1
 scipy>=1.10.0
 sqlite-vec>=0.1.6
+chromadb>=1.0.0
+redisvl>=0.8.0
+psycopg2-binary>=2.9.0
+pgvector>=0.4.1


### PR DESCRIPTION
## Summary
- document optional vector DB engines
- expose new storage engines
- implement ChromaDBEngine, PostgresVectorEngine, RedisVectorEngine
- add dependencies for vector databases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e06fff25c83338834fb2ad8bbadd0