### PR TITLE
Add support for additional memory types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ MindForge is a Python library designed to provide sophisticated memory managemen
     *   **User-Specific Memory:**  Tailored to individual users.
     *   **Session-Specific Memory:**  Contextual information for a single session.
     *   **Agent-Specific Memory:**  Knowledge and adaptability specific to the AI agent.
+    *   **Persona Memory:**  Relationship-building data for more natural interactions.
+    *   **Toolbox Memory:**  JSON schemas of available tools.
+    *   **Conversation Memory:**  History of LLM interactions.
+    *   **Workflow Memory:**  Past action outcomes to improve decisions.
+    *   **Episodic Memory:**  Collections of significant events.
+    *   **Agent Registry:**  Registry of available agents and capabilities.
+    *   **Entity Memory:**  Structured information about key entities.
 *   **Vector-Based Similarity Search:**  Uses `sqlite-vec` (and optionally FAISS) for fast and efficient retrieval of memories based on semantic similarity.
 *   **Concept Graph:**  Builds and maintains a graph of relationships between concepts, enabling spreading activation for enhanced retrieval.
 *   **Semantic Clustering:**  Groups memories based on their embeddings, improving retrieval efficiency and identifying related concepts.

--- a/mindforge/core/memory_store.py
+++ b/mindforge/core/memory_store.py
@@ -25,6 +25,14 @@ class MemoryStore:
         self.session_memory = defaultdict(list)
         # agent_memory stores a list of interaction_ids
         self.agent_memory = []
+        # Additional memory types
+        self.persona_memory = []
+        self.toolbox_memory = []
+        self.conversation_memory = []
+        self.workflow_memory = []
+        self.episodic_memory = []
+        self.registry_memory = []
+        self.entity_memory = []
 
         # Initialize the vector store
         self._init_vector_store()
@@ -73,6 +81,20 @@ class MemoryStore:
         elif memory_level == "long_term":
             # long_term_memory stores the full interaction, not just ID
             self.long_term_memory.append(interaction)
+        elif memory_level == "persona":
+            self.persona_memory.append(interaction_id)
+        elif memory_level == "toolbox":
+            self.toolbox_memory.append(interaction_id)
+        elif memory_level == "conversation":
+            self.conversation_memory.append(interaction_id)
+        elif memory_level == "workflow":
+            self.workflow_memory.append(interaction_id)
+        elif memory_level == "episodic":
+            self.episodic_memory.append(interaction_id)
+        elif memory_level == "registry":
+            self.registry_memory.append(interaction_id)
+        elif memory_level == "entity":
+            self.entity_memory.append(interaction_id)
         # No specific action for "short_term" as it's already in short_term_memory by default
 
     def retrieve(
@@ -164,6 +186,20 @@ class MemoryStore:
         elif memory_level == "long_term":
             # Assuming long_term_memory stores full interaction objects
             allowed_ids = {lt_interaction["id"] for lt_interaction in self.long_term_memory}
+        elif memory_level == "persona":
+            allowed_ids = set(self.persona_memory)
+        elif memory_level == "toolbox":
+            allowed_ids = set(self.toolbox_memory)
+        elif memory_level == "conversation":
+            allowed_ids = set(self.conversation_memory)
+        elif memory_level == "workflow":
+            allowed_ids = set(self.workflow_memory)
+        elif memory_level == "episodic":
+            allowed_ids = set(self.episodic_memory)
+        elif memory_level == "registry":
+            allowed_ids = set(self.registry_memory)
+        elif memory_level == "entity":
+            allowed_ids = set(self.entity_memory)
         elif memory_level == "short_term":
             # Interactions are already from short_term_memory via FAISS, so no ID filtering needed here.
             perform_filtering = False
@@ -172,8 +208,20 @@ class MemoryStore:
             perform_filtering = False
 
         if perform_filtering:
-            if not allowed_ids and memory_level in ["user", "session", "agent", "long_term"]:
-                 # If allowed_ids is empty for these specific levels, it means no relevant memories exist.
+            if not allowed_ids and memory_level in [
+                "user",
+                "session",
+                "agent",
+                "long_term",
+                "persona",
+                "toolbox",
+                "conversation",
+                "workflow",
+                "episodic",
+                "registry",
+                "entity",
+            ]:
+                # If allowed_ids is empty for these specific levels, it means no relevant memories exist.
                 return []
             return [
                 interaction for interaction in interactions if interaction["id"] in allowed_ids

--- a/mindforge/storage/sqlite_engine.py
+++ b/mindforge/storage/sqlite_engine.py
@@ -78,7 +78,20 @@ class SQLiteEngine(BaseStorage):
                     access_count INTEGER NOT NULL DEFAULT 1,
                     last_access REAL NOT NULL,
                     memory_type TEXT CHECK(
-                        memory_type IN ('short_term', 'long_term', 'user', 'session', 'agent')
+                        memory_type IN (
+                            'short_term',
+                            'long_term',
+                            'user',
+                            'session',
+                            'agent',
+                            'persona',
+                            'toolbox',
+                            'conversation',
+                            'workflow',
+                            'episodic',
+                            'registry',
+                            'entity'
+                        )
                     ) NOT NULL,
                     recency_boost REAL DEFAULT 1.0
                 );
@@ -296,6 +309,13 @@ class SQLiteEngine(BaseStorage):
                     JOIN agent_memories am_filter ON m.id = am_filter.memory_id
                 """
                 params = ([query_vector, limit * 2] if self.vec_enabled else [])
+            elif memory_type:
+                type_join = "WHERE m.memory_type = ?"
+                params = (
+                    [query_vector, limit * 2, memory_type]
+                    if self.vec_enabled
+                    else [memory_type]
+                )
             else:
                 type_join = ""
                 params = ([query_vector, limit * 2] if self.vec_enabled else [])


### PR DESCRIPTION
## Summary
- add persona, toolbox, conversation, workflow, episodic, registry and entity memory levels
- allow filtering by these new memory types in `MemoryStore` and `SQLiteEngine`
- document new memory types in README

## Testing
- `pip install numpy faiss-cpu sqlite-vec scikit-learn scipy requests litellm chromadb redisvl psycopg2-binary pgvector -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620ae91b588333bfb953dd917dcf5d